### PR TITLE
Fix incorrect link to ValveKeyValue

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
 							<p>.NET library to read and write files in Valve key value format. This library aims to be fully compatible with Valve's various implementations of KeyValues format parsing.</p>
 
 							<a href="https://www.nuget.org/packages/ValveKeyValue">Get ValveKeyValue from NuGet</a> |
-							<a href="https://github.com/ValveResourceFormat/ValveResourceFormat">View on GitHub</a>
+							<a href="https://github.com/ValveResourceFormat/ValveKeyValue">View on GitHub</a>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
**"View on GitHub"** button in **"ValveKeyValue"** section leads to [ValveResourceFormat/ValveResourceFormat](https://github.com/ValveResourceFormat/ValveResourceFormat), not [ValveResourceFormat/ValveKeyValue](https://github.com/ValveResourceFormat/ValveKeyValue).

This PR fixes this issue.